### PR TITLE
Compat with QEPOptimize: Fix visualization of T1, T2 for Quantikz extention, add affectedqubits() 

### DIFF
--- a/ext/BPGatesQuantikzExt/BPGatesQuantikzExt.jl
+++ b/ext/BPGatesQuantikzExt/BPGatesQuantikzExt.jl
@@ -33,5 +33,8 @@ Quantikz.QuantikzOp(op::PauliNoiseBellGate) = Quantikz.QuantikzOp(op.g)
 Quantikz.QuantikzOp(op::NoisyBellMeasure) = Quantikz.QuantikzOp(op.m)
 Quantikz.QuantikzOp(op::NoisyBellMeasureNoisyReset) = Quantikz.QuantikzOp(op.m)
 
+# Add t1 and t2 noise op visualizations, to show as a gate with 'T1' and 'T2' labels, and also the λ values in the label
+Quantikz.QuantikzOp(op::T1NoiseOp) = Quantikz.U(small_vert_matrix(("\\mathcal{\\lambda}_1",round(op.λ₁, digits=2)), "\\ T_1"), op.idx)
+Quantikz.QuantikzOp(op::T2NoiseOp) = Quantikz.U(small_vert_matrix(("\\mathcal{\\lambda}_2",round(op.λ₂, digits=2)), "\\ T_2"), op.idx)
 
 end

--- a/src/BPGates.jl
+++ b/src/BPGates.jl
@@ -10,7 +10,7 @@ export BellState,
     BellMeasure, bellmeasure!,
     BellGate, CNOTPerm, GoodSingleQubitPerm,
     PauliNoiseOp, PauliNoiseBellGate, NoisyBellMeasure, NoisyBellMeasureNoisyReset,
-    BellSwap, NoisyBellSwap
+    BellSwap, NoisyBellSwap, T1NoiseOp, T2NoiseOp
 
 const IT = Union{Int8,Int16,Int32,Int64,UInt8,UInt16,UInt32,UInt64}
 

--- a/src/BPGates.jl
+++ b/src/BPGates.jl
@@ -852,4 +852,11 @@ function BellState(s::Stabilizer)
     return BellState(bits)
 end
 
+# Get the qubit pairs involved in an operation
+affectedqubits(gate::PauliNoiseBellGate) = (gate.g.idx1, gate.g.idx2)
+affectedqubits(gate::NoisyBellMeasureNoisyReset) = (gate.m.sidx,)
+affectedqubits(gate::BellMeasure) = (gate.sidx,)
+affectedqubits(gate::CNOTPerm) = (gate.idx1, gate.idx2)
+affectedqubits(gate)= ()  # Default case for gates that do not involve qubits
+
 end # module


### PR DESCRIPTION
T1 and T2 errors now show up if using the extension for Quantikz.displaycircuit. Added 'affectedqubits' function following format from quantikz. This will return the qubit pairs from a given operation. These changes are made to fit BPGates better into QuantumSavory/QEPOptimize. No additions to tests or docs (yet). 