### PR TITLE
Run JET in a dedicated test environment

### DIFF
--- a/.github/workflows/changelog-enforcer.yml
+++ b/.github/workflows/changelog-enforcer.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   # Enforces the update of a changelog file on every pull request 
   changelog:
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
     - uses: dangoslen/changelog-enforcer@v3

--- a/.github/workflows/ci-julia-nightly.yml
+++ b/.github/workflows/ci-julia-nightly.yml
@@ -40,9 +40,10 @@ jobs:
       - uses: julia-actions/cache@v3
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
+        with:
+          test_args: ${{ matrix.jet == 'true' && 'jet' || '' }}
         env:
           JULIA_NUM_THREADS: ${{ matrix.threads }}
-          JET_TEST: ${{ matrix.jet }}
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v7
         with:

--- a/.github/workflows/ci-julia-nightly.yml
+++ b/.github/workflows/ci-julia-nightly.yml
@@ -16,7 +16,7 @@ env:
   PYTHON: ~
 jobs:
   test:
-    name: Julia ${{ matrix.version }} - t=${{ matrix.threads }} - jet=${{ matrix.jet }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    name: Julia ${{ matrix.version }} - t=${{ matrix.threads }} - tests=${{ matrix.test_args }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -26,12 +26,12 @@ jobs:
             arch: x64
             version: alpha
             threads: 2
-            jet: 'false'
+            test_args: general
           - os: ubuntu-latest
             arch: x64
             version: '1'
             threads: 2
-            jet: 'true'
+            test_args: jet
     steps:
       - uses: actions/checkout@v6
       - uses: julia-actions/install-juliaup@v3
@@ -41,7 +41,7 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
         with:
-          test_args: ${{ matrix.jet == 'true' && 'jet' || '' }}
+          test_args: ${{ matrix.test_args }}
         env:
           JULIA_NUM_THREADS: ${{ matrix.threads }}
       - uses: julia-actions/julia-processcoverage@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
   docs:
     name: Documentation
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/Project.toml
+++ b/Project.toml
@@ -3,6 +3,9 @@ uuid = "2c1a90cd-bec4-4415-ae35-245016909a8f"
 authors = ["Shu Ge <geshu@mit.edu>", "Stefan Krastanov <stefan@krastanov.org>", "BPGates contributors"]
 version = "1.3.0"
 
+[workspace]
+projects = ["test", "test/projects/jet"]
+
 [deps]
 QuantumClifford = "0525e862-1e90-11e9-3e4d-1b39d7109de1"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/test/projects/jet/Project.toml
+++ b/test/projects/jet/Project.toml
@@ -1,0 +1,9 @@
+[deps]
+BPGates = "2c1a90cd-bec4-4415-ae35-245016909a8f"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+TestItemRunner = "f8b46487-2199-4994-9208-9a1283c18c0a"
+
+[sources]
+BPGates = {path = "../../.."}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,13 +1,13 @@
-JET_flag = false
+JET_flag = ARGS == ["jet"]
 
-if get(ENV, "JET_TEST", "") == "true"
-    JET_flag = true
+if JET_flag
+    @info "Running JET tests in their dedicated test environment."
+    using Pkg
+    Pkg.activate(joinpath(@__DIR__, "projects", "jet"))
+    Pkg.instantiate()
 else
-    @info "Skipping JET tests -- must be explicitly enabled."
+    @info "Skipping JET tests -- pass `test_args=[\"jet\"]` to Pkg.test to enable them."
 end
-
-using Pkg
-JET_flag && Pkg.add("JET")
 
 using BPGates
 using TestItemRunner

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,12 +1,12 @@
-JET_flag = ARGS == ["jet"]
+const JET_PROJECT = normpath(joinpath(@__DIR__, "projects", "jet"))
+const test_args = isempty(ARGS) ? ["general"] : ARGS
+const JET_flag = length(test_args) == 1 && startswith(only(test_args), "jet")
 
 if JET_flag
-    @info "Running JET tests in their dedicated test environment."
+    @info "Activating the dedicated JET test environment." project=JET_PROJECT
     using Pkg
-    Pkg.activate(joinpath(@__DIR__, "projects", "jet"))
+    Pkg.activate(JET_PROJECT)
     Pkg.instantiate()
-else
-    @info "Skipping JET tests -- pass `test_args=[\"jet\"]` to Pkg.test to enable them."
 end
 
 using BPGates


### PR DESCRIPTION
## Summary

- move JET into `test/projects/jet` instead of adding it dynamically
- route the stable JET matrix entry through `test_args: jet`
- skip documentation and changelog checks for Dependabot pull requests

## Validation

- `Pkg.test(test_args=["jet"])`
- `gh act -n --validate`
- workflow YAML and TOML parse; `git diff --check`