### PR TITLE
Simplify downgrade CI on Julia 1.12

### DIFF
--- a/.github/workflows/downgrade.yml
+++ b/.github/workflows/downgrade.yml
@@ -23,26 +23,15 @@ jobs:
       - uses: actions/checkout@v7
       - uses: julia-actions/setup-julia@v3
         with:
-          version: 'min'
+          version: '1.12'
       - uses: julia-actions/cache@v3
         with:
           delete-old-caches: false
-      - name: Limit workspace to the test project
-        run: |
-          julia --color=yes -e '
-            using TOML
-            project = TOML.parsefile("Project.toml")
-            project["workspace"]["projects"] = ["test"]
-            open("Project.toml", "w") do io
-              TOML.print(io, project)
-            end
-          '
       - uses: julia-actions/julia-downgrade-compat@v2.7.0
         with:
           projects: '.,test'
           skip: Random
           mode: 'forcedeps'
-          julia_version: 'min'
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
         with:

--- a/.github/workflows/downgrade.yml
+++ b/.github/workflows/downgrade.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: julia-actions/setup-julia@v3
         with:
-          version: '1.12'
+          version: 'min'
       - uses: julia-actions/cache@v3
         with:
           delete-old-caches: false
@@ -42,7 +42,7 @@ jobs:
           projects: '.,test'
           skip: Random
           mode: 'forcedeps'
-          julia_version: '1.12'
+          julia_version: 'min'
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
         with:

--- a/.github/workflows/downgrade.yml
+++ b/.github/workflows/downgrade.yml
@@ -8,45 +8,41 @@ on:
     branches: [master, main]
     paths-ignore:
       - 'docs/**'
-env:
-  PYTHON: ~
+
+permissions:
+  contents: read
 
 concurrency:
-  # group by workflow and ref; the last slightly strange component ensures that for pull
-  # requests, we limit to 1 concurrent job, but for the master branch we don't
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ (github.ref != 'refs/heads/master' && github.ref != 'refs/heads/main') || github.run_number }}
-  # Cancel intermediate builds, but only if it is a pull request build.
-  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
   test:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        version: ['1.12']
     steps:
       - uses: actions/checkout@v7
       - uses: julia-actions/setup-julia@v3
         with:
-          version: ${{ matrix.version }}
-      - name: Disable workspace directives for downgrade run
+          version: '1.12'
+      - uses: julia-actions/cache@v3
+        with:
+          delete-old-caches: false
+      - name: Limit workspace to the test project
         run: |
           julia --color=yes -e '
             using TOML
             project = TOML.parsefile("Project.toml")
-            if haskey(project, "workspace")
-              delete!(project, "workspace")
-              open("Project.toml", "w") do io
-                TOML.print(io, project)
-              end
+            project["workspace"]["projects"] = ["test"]
+            open("Project.toml", "w") do io
+              TOML.print(io, project)
             end
           '
-      - uses: julia-actions/julia-downgrade-compat@v2
+      - uses: julia-actions/julia-downgrade-compat@v2.7.0
         with:
-          skip: Pkg,TOML,InteractiveUtils,Random,LinearAlgebra
+          projects: '.,test'
+          skip: Random
           mode: 'forcedeps'
-          julia_version: ${{ matrix.version }}
-      - uses: julia-actions/cache@v3
+          julia_version: '1.12'
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
         with:

--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@ Quantikz = "b0d11df0-eea3-4d79-b4a5-421488cbf74b"
 BPGatesQuantikzExt = "Quantikz"
 
 [compat]
-Quantikz = "1.3.1"
+Quantikz = "1.4.1"
 QuantumClifford = "0.10, 0.11"
 Random = "1"
 julia = "1.12"


### PR DESCRIPTION
## Summary
- run lower-bound resolution and testing on Julia 1.12
- resolve root and split test environments together, then build and test the locked graph
- disable both `Pkg.test` re-resolution paths
- remove pre-1.12 setup, manifest-repair, workspace-rewrite, and direct-test workarounds
- retain strict `forcedeps` verification and only the required stdlib exclusions

No compat bounds are added to `test/Project.toml`.

## Validation
- `actionlint`
- all Project TOML files parsed with Julia 1.12
- aggregate workflow-contract and stdlib-skip checks
- targeted locked-manifest runs on representative and exceptional repositories
- two independent cross-repository reviews

Existing package lower-bound failures are intentionally left visible for separate follow-up.