### PR TITLE
Fix Buildkite Codecov secret and coverage config

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -12,5 +12,4 @@ steps:
           version: "1"
       - QuantumSavory/julia-xvfb#v1:
       - JuliaCI/julia-test#v1: ~
-      - JuliaCI/julia-coverage#v1:
-          codecov: true
+      - JuliaCI/julia-coverage#v1: ~

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,8 +1,10 @@
 env:
-  CODECOV_TOKEN: 61f19b8a-59a0-4120-b30a-6b0cb93452c2
   JULIA_NUM_THREADS: auto
   QUANTUMSAVORY_PLOT_TEST: true
-  
+
+secrets:
+  - CODECOV_TOKEN
+
 steps:
   - label: "CI Buildkite"
     plugins:


### PR DESCRIPTION
## Summary

- load CODECOV_TOKEN from the existing Buildkite cluster secret
- use the supported explicit empty configuration for JuliaCI/julia-coverage#v1
- remove the obsolete codecov option

## Validation

- bk pipeline validate --file .buildkite/pipeline.yml
- git diff --check
- semantic YAML review of the secret and coverage configuration