### PR TITLE
Fix Julia 1.12 downgrade tests

### DIFF
--- a/.github/workflows/downgrade.yml
+++ b/.github/workflows/downgrade.yml
@@ -16,6 +16,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
+env:
+  QUANTUMSAVORY_DOWNGRADE_TEST: "true"
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -17,3 +17,4 @@ TestItemRunner = "f8b46487-2199-4994-9208-9a1283c18c0a"
 
 [compat]
 Static = ">= 0.3.2"
+TestItemRunner = "1.1.5"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -14,3 +14,6 @@ StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Static = "aedffcd0-7271-4cad-89d0-dc628f76c6d3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TestItemRunner = "f8b46487-2199-4994-9208-9a1283c18c0a"
+
+[compat]
+Static = ">= 0.3.2"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,7 +22,7 @@ testfilter = ti -> begin
     push!(exclude, :jet)
   end
 
-  if !(VERSION >= v"1.10")
+  if !(VERSION >= v"1.10") || get(ENV, "QUANTUMSAVORY_DOWNGRADE_TEST", "") == "true"
     push!(exclude, :doctests)
     push!(exclude, :aqua)
   end

--- a/test/test_aqua.jl
+++ b/test/test_aqua.jl
@@ -1,4 +1,4 @@
-@testitem "Aqua analysis" begin
+@testitem "Aqua analysis" tags=[:aqua] begin
 
 using Aqua, BPGates
 

--- a/test/test_doctests.jl
+++ b/test/test_doctests.jl
@@ -1,4 +1,4 @@
-@testitem "doctests" begin
+@testitem "doctests" tags=[:doctests] begin
 
 using Documenter
 using BPGates


### PR DESCRIPTION
## Summary

- Require Static 0.3.2 or later in the test project. Static 0.3.2 is the first release that loads on Julia 1.12.
- Require the latest registered TestItemRunner 1.1.5.
- Mark Aqua and doctest test items and exclude those quality checks during downgrade runs.
- Keep the downgrade action and its forced-dependency inputs unchanged.

## Diagnosis

Static 0.3.1 and earlier import Base.@aggressive_constprop, which is not defined on Julia 1.12. After resolving that floor, the locked test selected TestItemRunner 0.1.0 and failed because that release does not support the filter argument used by the test entry point.

## Validation

- Confirmed Static 0.3.1 fails and Static 0.3.2 loads on Julia 1.12.6.
- Ran julia-downgrade-compat v2.7.0 with the workflow exact projects, skip list, and forcedeps mode. Resolution passes and selects Static 0.3.2 plus TestItemRunner 1.1.5.
- Confirmed an ordinary update selects the current Static 1.4.6 release.
- Reproduced the TestItemRunner 0.1.0 macro failure; the amended locked test gets past that failure and runs package tests.
- Parsed the changed Julia files and TOML projects with Julia 1.12.6.
- Ran git diff --check.
- Hosted CI will validate the complete locked integration suite.